### PR TITLE
Add support for sentinel authentication

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -55,18 +55,20 @@ var (
 )
 
 type Exporter struct {
-	addr         string
-	namespace    string
-	metrics      map[string]*prometheus.GaugeVec
-	duration     prometheus.Gauge
-	scrapeErrors prometheus.Gauge
-	totalScrapes prometheus.Counter
+	addr              string
+	namespace         string
+	sentinel_password string
+	metrics           map[string]*prometheus.GaugeVec
+	duration          prometheus.Gauge
+	scrapeErrors      prometheus.Gauge
+	totalScrapes      prometheus.Counter
 }
 
-func NewRedisSentinelExporter(addr, namespace string) *Exporter {
+func NewRedisSentinelExporter(addr, namespace string, sentinel_password string) *Exporter {
 	e := &Exporter{
 		addr:      addr,
 		namespace: namespace,
+		sentinel_password: sentinel_password,
 		duration: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "exporter_last_scrape_duration_seconds",
@@ -138,6 +140,7 @@ func (e *Exporter) scrapeInfo() (string, error) {
 		redis.DialConnectTimeout(5 * time.Second),
 		redis.DialReadTimeout(5 * time.Second),
 		redis.DialWriteTimeout(5 * time.Second),
+		redis.DialPassword(e.sentinel_password),
 	}
 
 	logrus.Debugf("Trying DialURL(): %s", e.addr)

--- a/main.go
+++ b/main.go
@@ -13,13 +13,14 @@ import (
 )
 
 var (
-	listenAddress = flag.String("web.listen-address", ":9355", "Address to listen on for web interface and telemetry.")
-	metricPath    = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
-	sentinelAddr  = flag.String("sentinel.addr", "redis://127.0.0.1:26379", "Redis Sentinel host:port")
-	isDebug       = flag.Bool("debug", false, "Output verbose debug information")
-	logFormat     = flag.String("log-format", "txt", "Log format, valid options are txt and json")
-	namespace     = flag.String("namespace", "redis_sentinel", "Namespace for metrics")
-	versionPrint  = flag.Bool("version", false, "Prints version and exit")
+	listenAddress     = flag.String("web.listen-address", ":9355", "Address to listen on for web interface and telemetry.")
+	metricPath        = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+	sentinelAddr      = flag.String("sentinel.addr", "redis://127.0.0.1:26379", "Redis Sentinel host:port")
+	sentinelPassword  = flag.String("sentinel.password", "", "Redis Sentinel password (optional)")
+	isDebug           = flag.Bool("debug", false, "Output verbose debug information")
+	logFormat         = flag.String("log-format", "txt", "Log format, valid options are txt and json")
+	namespace         = flag.String("namespace", "redis_sentinel", "Namespace for metrics")
+	versionPrint      = flag.Bool("version", false, "Prints version and exit")
 )
 
 func main() {
@@ -48,7 +49,7 @@ func main() {
 		logrus.Fatal("Must specify a non-empty sentinel.addr")
 	}
 
-	exp := NewRedisSentinelExporter(*sentinelAddr, *namespace)
+	exp := NewRedisSentinelExporter(*sentinelAddr, *namespace, *sentinelPassword)
 
 	prometheus.MustRegister(exp)
 	http.Handle(*metricPath, promhttp.Handler())


### PR DESCRIPTION
Redis Sentinel has ability to require authentication like normal redis servers using `requirepass` directive. This PR will implement a new, optional flag `-sentinel.password` which will be used for authenticating against sentinel service.